### PR TITLE
Introduce multi-agent planner and model registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,43 @@
-# Rust CLI Coding Agent
+# Shellcraft Multi-Agent Coding Assistant
 
-Tiny terminal agent that proposes **full-file edits** with an OpenAI-compatible LLM.
-Review a colored diff, tweak in `$EDITOR`, then save.
+Shellcraft is a tiny terminal agent focused on coding tasks. It uses a
+chat-first, multi-agent architecture. A planner agent converses with you,
+breaks requests into detailed steps, and can delegate work to additional
+worker agents as needed.
+
+## Model configuration
+
+Available models live in `models.json`. Each entry specifies the provider
+and an environment variable that holds the API key. A default model is used
+when `MODEL_ID` is not set.
+
+Example `models.json`:
+```json
+{
+  "default_model": "gpt-4o-mini",
+  "models": [
+    {
+      "id": "gpt-4o-mini",
+      "provider": "openai",
+      "api_key_env": "OPENAI_API_KEY",
+      "has_tools": true,
+      "specialty": "general coding"
+    }
+  ]
+}
+```
 
 ## Setup
+
 ```bash
 cargo build
-export OPENAI_API_KEY="sk-..."                          # required
-# export OPENAI_BASE_URL="https://api.openai.com/v1"     # optional (default)
-# export MODEL_ID="gpt-4o-mini"                           # optional
+export OPENAI_API_KEY="sk-..."      # required for OpenAI models
+# export GROQ_API_KEY="sk-..."       # optional for Groq models
+# export MODEL_ID="gpt-4o-mini"      # override default model
+```
+
+Run the CLI and start chatting:
+
+```bash
+cargo run
+```

--- a/models.json
+++ b/models.json
@@ -1,0 +1,19 @@
+{
+  "default_model": "gpt-4o-mini",
+  "models": [
+    {
+      "id": "gpt-4o-mini",
+      "provider": "openai",
+      "api_key_env": "OPENAI_API_KEY",
+      "has_tools": true,
+      "specialty": "general coding"
+    },
+    {
+      "id": "llama-3.3-70b-versatile",
+      "provider": "groq",
+      "api_key_env": "GROQ_API_KEY",
+      "has_tools": false,
+      "specialty": "reasoning"
+    }
+  ]
+}

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -1,0 +1,60 @@
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::capabilities::Manifest;
+use crate::planner::{self, Plan};
+
+/// Trait for all agents in the system.
+pub trait Agent {
+    fn name(&self) -> &str;
+}
+
+/// Planner agent chats with the user and produces a plan.
+pub struct PlannerAgent {
+    pub model: String,
+}
+
+impl PlannerAgent {
+    pub fn new(model: String) -> Self {
+        Self { model }
+    }
+
+    pub fn default() -> Self {
+        let model = std::env::var("MODEL_ID").unwrap_or_default();
+        Self { model }
+    }
+
+    pub async fn chat_and_plan(
+        &self,
+        root: &Path,
+        user: &str,
+        manifest: &Manifest,
+    ) -> Result<Plan> {
+        planner::plan_changes(root, user, manifest).await
+    }
+}
+
+impl Agent for PlannerAgent {
+    fn name(&self) -> &str {
+        "planner"
+    }
+}
+
+/// Worker agent placeholder.
+pub struct WorkerAgent {
+    pub model: String,
+    pub tools: bool,
+}
+
+impl WorkerAgent {
+    pub fn new(model: String, tools: bool) -> Self {
+        Self { model, tools }
+    }
+}
+
+impl Agent for WorkerAgent {
+    fn name(&self) -> &str {
+        "worker"
+    }
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+use std::fs;
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ModelInfo {
+    pub id: String,
+    pub provider: String,
+    #[serde(default)]
+    pub api_key_env: String,
+    #[serde(default)]
+    pub has_tools: bool,
+    #[serde(default)]
+    pub specialty: String,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct ModelRegistry {
+    pub default_model: String,
+    #[serde(default)]
+    pub models: Vec<ModelInfo>,
+}
+
+impl ModelRegistry {
+    pub fn load() -> Self {
+        let path = std::env::var("MODEL_CONFIG").unwrap_or_else(|_| "models.json".into());
+        let data = fs::read_to_string(&path).unwrap_or_else(|_| "{}".into());
+        serde_json::from_str(&data).unwrap_or_else(|_| ModelRegistry {
+            default_model: "gpt-4o-mini".into(),
+            models: vec![],
+        })
+    }
+
+    pub fn get(&self, id: &str) -> Option<&ModelInfo> {
+        self.models.iter().find(|m| m.id == id)
+    }
+}


### PR DESCRIPTION
## Summary
- add model registry with sample `models.json` to manage multiple providers
- wire new planner agent and agent scaffolding for chat-first workflow
- route LLM calls through registry-aware provider selection

## Testing
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68be186ba6408324896abd1bd75e8dd2