### PR TITLE
Expose tool lists for capable models

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ worker agents as needed.
 
 Available models live in `models.json`. Each entry specifies the provider
 and an environment variable that holds the API key. A default model is used
-when `MODEL_ID` is not set.
+when `MODEL_ID` is not set. If a model supports tool calling, it can list the
+available tools in a `tools` array.
 
 Example `models.json`:
 ```json
@@ -20,7 +21,7 @@ Example `models.json`:
       "id": "gpt-4o-mini",
       "provider": "openai",
       "api_key_env": "OPENAI_API_KEY",
-      "has_tools": true,
+      "tools": ["code_interpreter"],
       "specialty": "general coding"
     }
   ]

--- a/models.json
+++ b/models.json
@@ -5,21 +5,21 @@
       "id": "openai/gpt-oss-120b",
       "provider": "groq",
       "api_key_env": "GROQ_API_KEY",
-      "has_tools": true,
+      "tools": ["code_interpreter"],
       "specialty": "reasoning"
     },
     {
       "id": "llama-3.3-70b-versatile",
       "provider": "groq",
       "api_key_env": "GROQ_API_KEY",
-      "has_tools": true,
+       "tools": ["code_interpreter"],
       "specialty": "versatile"
     },
     {
       "id": "llama-3.1-8b-instant",
       "provider": "groq",
       "api_key_env": "GROQ_API_KEY",
-      "has_tools": true,
+      "tools": ["code_interpreter"],
       "specialty": "chat"
     }
   ]

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -44,11 +44,11 @@ impl Agent for PlannerAgent {
 /// Worker agent placeholder.
 pub struct WorkerAgent {
     pub model: String,
-    pub tools: bool,
+    pub tools: Vec<String>,
 }
 
 impl WorkerAgent {
-    pub fn new(model: String, tools: bool) -> Self {
+    pub fn new(model: String, tools: Vec<String>) -> Self {
         Self { model, tools }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -8,7 +8,7 @@ pub struct ModelInfo {
     #[serde(default)]
     pub api_key_env: String,
     #[serde(default)]
-    pub has_tools: bool,
+    pub tools: Vec<String>,
     #[serde(default)]
     pub specialty: String,
 }


### PR DESCRIPTION
## Summary
- allow models to specify available tools via a `tools` list
- adjust worker agent to carry explicit tool lists
- document model tool arrays in README and sample models.json

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68be2b26e2588324a909e47b8683d608