### PR TITLE
Expose file deletion capability to planner

### DIFF
--- a/src/capabilities.rs
+++ b/src/capabilities.rs
@@ -121,7 +121,7 @@ pub fn can_run(manifest: &Manifest, program: &str) -> (bool, Option<String>) {
 pub fn system_preamble(manifest: &Manifest) -> String {
     let t = &manifest.tools;
     let mut lines = vec![
-        "You can propose file edits and also request actions to run tools.\nEnabled tools:"
+        "You can propose file edits and deletions and also request actions to run tools.\nEnabled tools:"
             .to_string(),
     ];
     let mut add = |name: &str, ok: bool| {

--- a/src/fsutil.rs
+++ b/src/fsutil.rs
@@ -38,7 +38,10 @@ pub fn file_inventory(root: &Path) -> Result<Vec<FileMeta>> {
                 out.push(FileMeta {
                     path: rel.to_string_lossy().to_string(),
                     size: md.len(),
-                    ext: p.extension().and_then(|s| s.to_str()).map(|s| s.to_string()),
+                    ext: p
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_string()),
                 });
             }
         }
@@ -90,4 +93,14 @@ pub fn merge_ignore_patterns(patterns: &[&str]) {
             let _ = writeln!(f, "{}", lines.join("\n"));
         }
     }
+}
+
+/// Remove a file or directory recursively.
+pub fn remove_path(p: &Path) -> Result<()> {
+    if p.is_dir() {
+        fs::remove_dir_all(p)?;
+    } else if p.is_file() {
+        fs::remove_file(p)?;
+    }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ mod fsutil;
 mod llm;
 mod models;
 mod planner;
-mod ui;
 mod task_ui;
+mod ui;
 
 // We inline a tiny diff preview + atomic write so we don't depend on
 // diff/editor symbols that may differ in your tree.
@@ -85,6 +85,20 @@ async fn orchestrate(user_input: &str) -> Result<()> {
                 println!("{content}");
             }
             Err(err) => eprintln!("{} {} ({err})", style("Failed to read:").red(), path),
+        }
+    }
+
+    // Deletes
+    for path in plan.delete.iter() {
+        let abs = root.join(path);
+        if abs.exists() {
+            if let Err(err) = fsutil::remove_path(&abs) {
+                eprintln!("{} {} ({err})", style("Failed to delete:").red(), path);
+            } else {
+                println!("{} {}", style("Deleted:").red(), path);
+            }
+        } else {
+            eprintln!("{} {} (not found)", style("Failed to delete:").red(), path);
         }
     }
 


### PR DESCRIPTION
## Summary
- Allow plans to specify files or directories to delete
- Document deletion support in planner guidance and capability preamble
- Provide filesystem utility for removing paths and execute deletes during orchestration

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68be2d25dc188324b42a923906625587